### PR TITLE
fix(GCP): Integrate KMS provider with Awala library

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,35 @@ The library is available on NPM as [`@relaycorp/awala-keystore-cloud`](https://w
 npm i @relaycorp/awala-keystore-cloud
 ```
 
+### Initialising the private key store
+
+The configuration of the adapter is done via environment variables, so the actual initialisation of the store is done with a simple function call. For example:
+
+```typescript
+import {
+  Adapter,
+  initPrivateKeystoreFromEnv,
+} from '@relaycorp/awala-keystore-cloud';
+import { PrivateKeyStore } from '@relaycorp/relaynet-core';
+
+async function initPrivateKeystore(): Promise<PrivateKeyStore> {
+  return initPrivateKeystoreFromEnv(Adapter.GCP);
+}
+```
+
+The following environment variables must be defined depending on the adapter:
+
+- GCP:
+  - `KS_GCP_LOCATION` (for example, `europe-west3`).
+  - `KS_KMS_KEYRING`: The KMS keyring holding all the keys to be used.
+  - `KS_KMS_ID_KEY`: The name of the KMS key whose versions will back Awala identity keys.
+  - `KS_KMS_SESSION_ENC_KEY`: The name of the KMS key used to encrypt Awala session keys.
+  - `KS_DATASTORE_NS`: The Datastore namespace to host all the key-related data.
+- Vault:
+  - `KS_VAULT_URL`: The URL to Vault.
+  - `KS_VAULT_TOKEN`: The user's access token.
+  - `KS_VAULT_KV_PREFIX`: The path prefix for the key-value backend.
+
 ## Development
 
 The unit test suite can be run the standard way on Node.js: `npm test`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
       "dependencies": {
         "@google-cloud/datastore": "^7.0.0",
         "@google-cloud/kms": "^3.0.0",
-        "@relaycorp/relaynet-core": "^1.81.0",
+        "@relaycorp/relaynet-core": "^1.81.1",
         "axios": "^0.27.2",
         "env-var": "^7.1.1",
         "fast-crc32c": "^2.0.0",
-        "webcrypto-core": "^1.7.3"
+        "webcrypto-core": "< 2.0"
       },
       "devDependencies": {
         "@relaycorp/shared-config": "^1.8.0",
@@ -33,6 +33,10 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@relaycorp/relaynet-core": "< 2.0",
+        "webcrypto-core": "< 2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1214,9 +1218,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@relaycorp/relaynet-core": {
-      "version": "1.81.0",
-      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.81.0.tgz",
-      "integrity": "sha512-HJ7qkN0/QSX4ftSPTnfXPfusovRkqO0Nhfcsg7gneJxcW6dPQh28ZoYoM5nsr55BYyPlBAYQl/N2DQGhRbICvA==",
+      "version": "1.81.1",
+      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.81.1.tgz",
+      "integrity": "sha512-MX33hcMDG4dxV1/zrPqGQhcEaTIeatMfmzavtyoAU5TsDrKEUG2XkJXOthc9Yd3QL77NG88CcIU3RSKZDvgddA==",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@stablelib/aes-kw": "^1.0.1",
@@ -11632,9 +11636,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@relaycorp/relaynet-core": {
-      "version": "1.81.0",
-      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.81.0.tgz",
-      "integrity": "sha512-HJ7qkN0/QSX4ftSPTnfXPfusovRkqO0Nhfcsg7gneJxcW6dPQh28ZoYoM5nsr55BYyPlBAYQl/N2DQGhRbICvA==",
+      "version": "1.81.1",
+      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.81.1.tgz",
+      "integrity": "sha512-MX33hcMDG4dxV1/zrPqGQhcEaTIeatMfmzavtyoAU5TsDrKEUG2XkJXOthc9Yd3QL77NG88CcIU3RSKZDvgddA==",
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "@stablelib/aes-kw": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@google-cloud/kms": "^3.0.0",
         "@relaycorp/relaynet-core": "< 2.0",
         "axios": "^0.27.2",
+        "env-var": "^7.1.1",
         "fast-crc32c": "^2.0.0",
         "webcrypto-core": "^1.7.3"
       },
@@ -3070,6 +3071,14 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-var": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.1.1.tgz",
+      "integrity": "sha512-4+vvlq+wwGQNwY/nI3/+Ojc1MKHCmITRJ6VWkQzDtMD6fAEb60ACRUCnlIAonMKW9YzqYmYxbyVu9vTb++yNRg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/error-ex": {
@@ -13121,6 +13130,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "env-var": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.1.1.tgz",
+      "integrity": "sha512-4+vvlq+wwGQNwY/nI3/+Ojc1MKHCmITRJ6VWkQzDtMD6fAEb60ACRUCnlIAonMKW9YzqYmYxbyVu9vTb++yNRg=="
     },
     "error-ex": {
       "version": "1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/datastore": "^7.0.0",
         "@google-cloud/kms": "^3.0.0",
-        "@relaycorp/relaynet-core": "< 2.0",
+        "@relaycorp/relaynet-core": "^1.81.0",
         "axios": "^0.27.2",
         "env-var": "^7.1.1",
         "fast-crc32c": "^2.0.0",
@@ -33,9 +33,6 @@
       },
       "engines": {
         "node": ">=14"
-      },
-      "peerDependencies": {
-        "@relaycorp/relaynet-core": "< 2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1217,9 +1214,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@relaycorp/relaynet-core": {
-      "version": "1.80.2",
-      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.80.2.tgz",
-      "integrity": "sha512-jtsW9bs7NJfMgcRoQszPXA0bbO5u26Mi5q6cSkSDOawwqQTCogRbXBXYo8WKP45AJ57ItLcGzTIJBmsqnOEAfQ==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.81.0.tgz",
+      "integrity": "sha512-HJ7qkN0/QSX4ftSPTnfXPfusovRkqO0Nhfcsg7gneJxcW6dPQh28ZoYoM5nsr55BYyPlBAYQl/N2DQGhRbICvA==",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@stablelib/aes-kw": "^1.0.1",
@@ -1238,6 +1235,9 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "peerDependencies": {
+        "webcrypto-core": "< 2"
       }
     },
     "node_modules/@relaycorp/shared-config": {
@@ -11632,9 +11632,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@relaycorp/relaynet-core": {
-      "version": "1.80.2",
-      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.80.2.tgz",
-      "integrity": "sha512-jtsW9bs7NJfMgcRoQszPXA0bbO5u26Mi5q6cSkSDOawwqQTCogRbXBXYo8WKP45AJ57ItLcGzTIJBmsqnOEAfQ==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@relaycorp/relaynet-core/-/relaynet-core-1.81.0.tgz",
+      "integrity": "sha512-HJ7qkN0/QSX4ftSPTnfXPfusovRkqO0Nhfcsg7gneJxcW6dPQh28ZoYoM5nsr55BYyPlBAYQl/N2DQGhRbICvA==",
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "@stablelib/aes-kw": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@google-cloud/datastore": "^7.0.0",
     "@google-cloud/kms": "^3.0.0",
-    "@relaycorp/relaynet-core": "< 2.0",
+    "@relaycorp/relaynet-core": "^1.81.0",
     "axios": "^0.27.2",
     "env-var": "^7.1.1",
     "fast-crc32c": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -43,14 +43,15 @@
   "dependencies": {
     "@google-cloud/datastore": "^7.0.0",
     "@google-cloud/kms": "^3.0.0",
-    "@relaycorp/relaynet-core": "^1.81.0",
+    "@relaycorp/relaynet-core": "^1.81.1",
     "axios": "^0.27.2",
     "env-var": "^7.1.1",
     "fast-crc32c": "^2.0.0",
     "webcrypto-core": "^1.7.3"
   },
   "peerDependencies": {
-    "@relaycorp/relaynet-core": "< 2.0"
+    "@relaycorp/relaynet-core": "< 2.0",
+    "webcrypto-core": "< 2.0"
   },
   "devDependencies": {
     "@relaycorp/shared-config": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@google-cloud/kms": "^3.0.0",
     "@relaycorp/relaynet-core": "< 2.0",
     "axios": "^0.27.2",
+    "env-var": "^7.1.1",
     "fast-crc32c": "^2.0.0",
     "webcrypto-core": "^1.7.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Adapter } from './lib/Adapter';
 export { initPrivateKeystoreFromEnv } from './lib/init';
 export { CloudKeystoreError } from './lib/CloudKeystoreError';
+export { CloudPrivateKeystore } from './lib/CloudPrivateKeystore';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { GCPPrivateKeyStore } from './lib/gcp/GCPPrivateKeyStore';
-
-export { VaultPrivateKeyStore } from './lib/vault/VaultPrivateKeyStore';
+export { Adapter } from './lib/Adapter';
+export { initPrivateKeystoreFromEnv } from './lib/init';
+export { CloudKeystoreError } from './lib/CloudKeystoreError';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { GCPPrivateKeyStore } from './lib/gcp/GCPPrivateKeyStore';
 
-export { VaultPrivateKeyStore } from './lib/vault/vaultPrivateKeyStore';
+export { VaultPrivateKeyStore } from './lib/vault/VaultPrivateKeyStore';

--- a/src/lib/Adapter.ts
+++ b/src/lib/Adapter.ts
@@ -1,0 +1,3 @@
+export enum Adapter {
+  VAULT,
+}

--- a/src/lib/Adapter.ts
+++ b/src/lib/Adapter.ts
@@ -1,3 +1,4 @@
 export enum Adapter {
+  GCP,
   VAULT,
 }

--- a/src/lib/CloudKeystoreError.ts
+++ b/src/lib/CloudKeystoreError.ts
@@ -1,0 +1,3 @@
+import { RelaynetError } from '@relaycorp/relaynet-core';
+
+export class CloudKeystoreError extends RelaynetError {}

--- a/src/lib/CloudPrivateKeystore.ts
+++ b/src/lib/CloudPrivateKeystore.ts
@@ -1,0 +1,5 @@
+import { PrivateKeyStore } from '@relaycorp/relaynet-core';
+
+export abstract class CloudPrivateKeystore extends PrivateKeyStore {
+  public abstract close(): Promise<void>;
+}

--- a/src/lib/gcp/GCPKeystoreError.ts
+++ b/src/lib/gcp/GCPKeystoreError.ts
@@ -1,3 +1,3 @@
-import { RelaynetError } from '@relaycorp/relaynet-core';
+import { CloudKeystoreError } from '../CloudKeystoreError';
 
-export class GCPKeystoreError extends RelaynetError {}
+export class GCPKeystoreError extends CloudKeystoreError {}

--- a/src/lib/gcp/GCPPrivateKeyStore.spec.ts
+++ b/src/lib/gcp/GCPPrivateKeyStore.spec.ts
@@ -1238,6 +1238,23 @@ describe('Session keys', () => {
   });
 });
 
+describe('close', () => {
+  test('KMS client should be closed', async () => {
+    const kmsClient = makeKMSClient();
+    const store = new GCPPrivateKeyStore(kmsClient, null as any, KMS_CONFIG);
+
+    await store.close();
+
+    expect(kmsClient.close).toBeCalled();
+  });
+
+  function makeKMSClient(): KeyManagementServiceClient {
+    const kmsClient = new KeyManagementServiceClient();
+    jest.spyOn(kmsClient, 'close').mockImplementation(async () => undefined);
+    return kmsClient;
+  }
+});
+
 function makeKmsClientWithMockProject(): KeyManagementServiceClient {
   const kmsClient = new KeyManagementServiceClient();
   jest.spyOn(kmsClient, 'getProjectId').mockImplementation(() => GCP_PROJECT);

--- a/src/lib/gcp/GCPPrivateKeyStore.ts
+++ b/src/lib/gcp/GCPPrivateKeyStore.ts
@@ -4,7 +4,6 @@ import {
   derDeserializeRSAPublicKey,
   getPrivateAddressFromIdentityKey,
   IdentityKeyPair,
-  PrivateKeyStore,
   RSAKeyGenOptions,
   SessionPrivateKeyData,
 } from '@relaycorp/relaynet-core';
@@ -16,6 +15,7 @@ import { GCPKeystoreError } from './GCPKeystoreError';
 import { GcpKmsRsaPssPrivateKey } from './GcpKmsRsaPssPrivateKey';
 import { wrapGCPCallError } from './gcpUtils';
 import { retrieveKMSPublicKey } from './kmsUtils';
+import { CloudPrivateKeystore } from '../CloudPrivateKeystore';
 
 export interface KMSConfig {
   readonly location: string;
@@ -35,7 +35,7 @@ interface ADDRequestParams {
   readonly additionalAuthenticatedDataCrc32c: { readonly value: number };
 }
 
-export class GCPPrivateKeyStore extends PrivateKeyStore {
+export class GCPPrivateKeyStore extends CloudPrivateKeystore {
   constructor(
     protected kmsClient: KeyManagementServiceClient,
     protected datastoreClient: Datastore,
@@ -93,6 +93,10 @@ export class GCPPrivateKeyStore extends PrivateKeyStore {
       keyDocument.version,
     );
     return new GcpKmsRsaPssPrivateKey(kmsKeyPath);
+  }
+
+  public async close(): Promise<void> {
+    await this.kmsClient.close();
   }
 
   protected async saveIdentityKey(): Promise<void> {

--- a/src/lib/gcp/GcpKmsRsaPssPrivateKey.spec.ts
+++ b/src/lib/gcp/GcpKmsRsaPssPrivateKey.spec.ts
@@ -1,33 +1,36 @@
 import { GcpKmsRsaPssPrivateKey } from './GcpKmsRsaPssPrivateKey';
+import { GcpKmsRsaPssProvider } from './GcpKmsRsaPssProvider';
 
 const KMS_KEY_PATH = 'projects/foo/key/42';
 
+const KMS_PROVIDER = new GcpKmsRsaPssProvider(null as any);
+
 test('KMS key path should be honored', () => {
-  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH);
+  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH, KMS_PROVIDER);
 
   expect(key.kmsKeyVersionPath).toEqual(KMS_KEY_PATH);
 });
 
+test('Crypto provider should be honored', () => {
+  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH, KMS_PROVIDER);
+
+  expect(key.provider).toBe(KMS_PROVIDER);
+});
+
 test('Algorithm should be RSA-PSS', () => {
-  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH);
+  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH, KMS_PROVIDER);
 
   expect(key.algorithm.name).toEqual('RSA-PSS');
 });
 
 test('Usage should be "sign"', () => {
-  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH);
+  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH, KMS_PROVIDER);
 
   expect(key.usages).toEqual(['sign']);
 });
 
-test('Key type should be private', () => {
-  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH);
-
-  expect(key.type).toEqual('private');
-});
-
 test('Key should be extractable', () => {
-  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH);
+  const key = new GcpKmsRsaPssPrivateKey(KMS_KEY_PATH, KMS_PROVIDER);
 
   expect(key.extractable).toBeTrue();
 });

--- a/src/lib/gcp/GcpKmsRsaPssPrivateKey.ts
+++ b/src/lib/gcp/GcpKmsRsaPssPrivateKey.ts
@@ -1,10 +1,12 @@
-import { CryptoKey } from 'webcrypto-core';
+import { PrivateKey } from '@relaycorp/relaynet-core';
 
-export class GcpKmsRsaPssPrivateKey extends CryptoKey {
-  constructor(public kmsKeyVersionPath: string) {
-    super();
+import { GcpKmsRsaPssProvider } from './GcpKmsRsaPssProvider';
+
+export class GcpKmsRsaPssPrivateKey extends PrivateKey {
+  constructor(public kmsKeyVersionPath: string, provider: GcpKmsRsaPssProvider) {
+    super(provider);
+
     this.algorithm = { name: 'RSA-PSS' };
-    this.type = 'private';
     this.usages = ['sign'];
     this.extractable = true; // The public key is exportable
   }

--- a/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
+++ b/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
@@ -12,7 +12,10 @@ import * as kmsUtils from './kmsUtils';
 
 const ALGORITHM = { name: 'RSA-PSS', saltLength: 32 };
 
-const PRIVATE_KEY = new GcpKmsRsaPssPrivateKey('/the/path/key-name');
+const PRIVATE_KEY = new GcpKmsRsaPssPrivateKey(
+  '/the/path/key-name',
+  new GcpKmsRsaPssProvider(null as any),
+);
 
 describe('hashingAlgorithms', () => {
   test('Only SHA-256 and SHA-512 should be supported', async () => {

--- a/src/lib/gcp/GcpKmsRsaPssProvider.ts
+++ b/src/lib/gcp/GcpKmsRsaPssProvider.ts
@@ -15,7 +15,7 @@ const SUPPORTED_SALT_LENGTHS: readonly number[] = [
 ];
 
 export class GcpKmsRsaPssProvider extends RsaPssProvider {
-  constructor(protected kmsClient: KeyManagementServiceClient) {
+  constructor(public kmsClient: KeyManagementServiceClient) {
     super();
 
     // See: https://cloud.google.com/kms/docs/algorithms#rsa_signing_algorithms

--- a/src/lib/init.spec.ts
+++ b/src/lib/init.spec.ts
@@ -1,12 +1,16 @@
+import { Datastore } from '@google-cloud/datastore';
+import { KeyManagementServiceClient } from '@google-cloud/kms';
 import { EnvVarError } from 'env-var';
 
 import { configureMockEnvVars } from '../testUtils/envVars';
 import { initPrivateKeystoreFromEnv } from './init';
 import { Adapter } from './Adapter';
-import * as vaultKeyStore from './vault/VaultPrivateKeyStore';
+import * as vaultKeystore from './vault/VaultPrivateKeyStore';
 import { CloudKeystoreError } from './CloudKeystoreError';
+import * as gcpKeystore from './gcp/GCPPrivateKeyStore';
 
 jest.mock('./vault/VaultPrivateKeyStore');
+jest.mock('./gcp/GCPPrivateKeyStore');
 
 describe('initPrivateKeyStoreFromEnv', () => {
   test('Unknown adapter should be refused', () => {
@@ -25,7 +29,7 @@ describe('initPrivateKeyStoreFromEnv', () => {
     };
     const mockEnvVars = configureMockEnvVars(BASE_ENV_VARS);
 
-    test.each(['VAULT_URL', 'VAULT_TOKEN', 'VAULT_KV_PREFIX'])(
+    test.each(Object.getOwnPropertyNames(BASE_ENV_VARS))(
       'Environment variable %s should be present',
       (envVar) => {
         mockEnvVars({ ...BASE_ENV_VARS, [envVar]: undefined });
@@ -40,11 +44,50 @@ describe('initPrivateKeyStoreFromEnv', () => {
     test('Key store should be returned if env vars are present', () => {
       const keyStore = initPrivateKeystoreFromEnv(Adapter.VAULT);
 
-      expect(keyStore).toBeInstanceOf(vaultKeyStore.VaultPrivateKeyStore);
-      expect(vaultKeyStore.VaultPrivateKeyStore).toBeCalledWith(
+      expect(keyStore).toBeInstanceOf(vaultKeystore.VaultPrivateKeyStore);
+      expect(vaultKeystore.VaultPrivateKeyStore).toBeCalledWith(
         BASE_ENV_VARS.VAULT_URL,
         BASE_ENV_VARS.VAULT_TOKEN,
         BASE_ENV_VARS.VAULT_KV_PREFIX,
+      );
+    });
+  });
+
+  describe('GPC', () => {
+    const BASE_ENV_VARS = {
+      KS_GCP_LOCATION: 'westeros-3',
+      KS_DATASTORE_NS: 'the-namespace',
+      KS_PRIV_KMS_KEYRING: 'my-precious',
+      KS_PRIV_KMS_ID_KEY: 'id',
+      KS_PRIV_KMS_SESSION_ENC_KEY: 'session',
+    };
+    const mockEnvVars = configureMockEnvVars(BASE_ENV_VARS);
+
+    test.each(Object.getOwnPropertyNames(BASE_ENV_VARS))(
+      'Environment variable %s should be present',
+      (envVar) => {
+        mockEnvVars({ ...BASE_ENV_VARS, [envVar]: undefined });
+
+        expect(() => initPrivateKeystoreFromEnv(Adapter.GCP)).toThrowWithMessage(
+          EnvVarError,
+          new RegExp(envVar),
+        );
+      },
+    );
+
+    test('Key store should be returned if env vars are present', async () => {
+      const keyStore = initPrivateKeystoreFromEnv(Adapter.GCP);
+
+      expect(keyStore).toBeInstanceOf(gcpKeystore.GCPPrivateKeyStore);
+      expect(gcpKeystore.GCPPrivateKeyStore).toBeCalledWith(
+        expect.any(KeyManagementServiceClient),
+        expect.toSatisfy<Datastore>((d) => d.namespace === BASE_ENV_VARS.KS_DATASTORE_NS),
+        expect.objectContaining<gcpKeystore.KMSConfig>({
+          identityKeyId: BASE_ENV_VARS.KS_PRIV_KMS_ID_KEY,
+          keyRing: BASE_ENV_VARS.KS_PRIV_KMS_KEYRING,
+          location: BASE_ENV_VARS.KS_GCP_LOCATION,
+          sessionEncryptionKeyId: BASE_ENV_VARS.KS_PRIV_KMS_SESSION_ENC_KEY,
+        }),
       );
     });
   });

--- a/src/lib/init.spec.ts
+++ b/src/lib/init.spec.ts
@@ -1,0 +1,51 @@
+import { EnvVarError } from 'env-var';
+
+import { configureMockEnvVars } from '../testUtils/envVars';
+import { initPrivateKeystoreFromEnv } from './init';
+import { Adapter } from './Adapter';
+import * as vaultKeyStore from './vault/VaultPrivateKeyStore';
+import { CloudKeystoreError } from './CloudKeystoreError';
+
+jest.mock('./vault/VaultPrivateKeyStore');
+
+describe('initPrivateKeyStoreFromEnv', () => {
+  test('Unknown adapter should be refused', () => {
+    const invalidAdapter = 'potato';
+    expect(() => initPrivateKeystoreFromEnv(invalidAdapter as any)).toThrowWithMessage(
+      CloudKeystoreError,
+      `Invalid private keystore adapter (${invalidAdapter})`,
+    );
+  });
+
+  describe('Vault', () => {
+    const BASE_ENV_VARS = {
+      VAULT_KV_PREFIX: 'kv-prefix',
+      VAULT_TOKEN: 'token',
+      VAULT_URL: 'http://hi.lol',
+    };
+    const mockEnvVars = configureMockEnvVars(BASE_ENV_VARS);
+
+    test.each(['VAULT_URL', 'VAULT_TOKEN', 'VAULT_KV_PREFIX'])(
+      'Environment variable %s should be present',
+      (envVar) => {
+        mockEnvVars({ ...BASE_ENV_VARS, [envVar]: undefined });
+
+        expect(() => initPrivateKeystoreFromEnv(Adapter.VAULT)).toThrowWithMessage(
+          EnvVarError,
+          new RegExp(envVar),
+        );
+      },
+    );
+
+    test('Key store should be returned if env vars are present', () => {
+      const keyStore = initPrivateKeystoreFromEnv(Adapter.VAULT);
+
+      expect(keyStore).toBeInstanceOf(vaultKeyStore.VaultPrivateKeyStore);
+      expect(vaultKeyStore.VaultPrivateKeyStore).toBeCalledWith(
+        BASE_ENV_VARS.VAULT_URL,
+        BASE_ENV_VARS.VAULT_TOKEN,
+        BASE_ENV_VARS.VAULT_KV_PREFIX,
+      );
+    });
+  });
+});

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -27,16 +27,16 @@ export function initGCPKeystore(): GCPPrivateKeyStore {
   });
   const kmsConfig = {
     location: getEnvVar('KS_GCP_LOCATION').required().asString(),
-    keyRing: getEnvVar('KS_PRIV_KMS_KEYRING').required().asString(),
-    identityKeyId: getEnvVar('KS_PRIV_KMS_ID_KEY').required().asString(),
-    sessionEncryptionKeyId: getEnvVar('KS_PRIV_KMS_SESSION_ENC_KEY').required().asString(),
+    keyRing: getEnvVar('KS_KMS_KEYRING').required().asString(),
+    identityKeyId: getEnvVar('KS_KMS_ID_KEY').required().asString(),
+    sessionEncryptionKeyId: getEnvVar('KS_KMS_SESSION_ENC_KEY').required().asString(),
   };
   return new GCPPrivateKeyStore(new KeyManagementServiceClient(), datastore, kmsConfig);
 }
 
 export function initVaultKeystore(): VaultPrivateKeyStore {
-  const vaultUrl = getEnvVar('VAULT_URL').required().asString();
-  const vaultToken = getEnvVar('VAULT_TOKEN').required().asString();
-  const vaultKvPath = getEnvVar('VAULT_KV_PREFIX').required().asString();
+  const vaultUrl = getEnvVar('KS_VAULT_URL').required().asString();
+  const vaultToken = getEnvVar('KS_VAULT_TOKEN').required().asString();
+  const vaultKvPath = getEnvVar('KS_VAULT_KV_PREFIX').required().asString();
   return new VaultPrivateKeyStore(vaultUrl, vaultToken, vaultKvPath);
 }

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,0 +1,25 @@
+import { PrivateKeyStore } from '@relaycorp/relaynet-core';
+import { get as getEnvVar } from 'env-var';
+
+import { Adapter } from './Adapter';
+import { VaultPrivateKeyStore } from './vault/VaultPrivateKeyStore';
+import { CloudKeystoreError } from './CloudKeystoreError';
+
+const ADAPTER_INITIALISERS = {
+  [Adapter.VAULT]: initVaultKeystore,
+};
+
+export function initPrivateKeystoreFromEnv(adapter: Adapter): PrivateKeyStore {
+  const init = ADAPTER_INITIALISERS[adapter];
+  if (!init) {
+    throw new CloudKeystoreError(`Invalid private keystore adapter (${adapter})`);
+  }
+  return init();
+}
+
+export function initVaultKeystore(): VaultPrivateKeyStore {
+  const vaultUrl = getEnvVar('VAULT_URL').required().asString();
+  const vaultToken = getEnvVar('VAULT_TOKEN').required().asString();
+  const vaultKvPath = getEnvVar('VAULT_KV_PREFIX').required().asString();
+  return new VaultPrivateKeyStore(vaultUrl, vaultToken, vaultKvPath);
+}

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,11 +1,15 @@
+import { Datastore } from '@google-cloud/datastore';
+import { KeyManagementServiceClient } from '@google-cloud/kms';
 import { get as getEnvVar } from 'env-var';
 
 import { Adapter } from './Adapter';
 import { VaultPrivateKeyStore } from './vault/VaultPrivateKeyStore';
 import { CloudKeystoreError } from './CloudKeystoreError';
 import { CloudPrivateKeystore } from './CloudPrivateKeystore';
+import { GCPPrivateKeyStore } from './gcp/GCPPrivateKeyStore';
 
 const ADAPTER_INITIALISERS = {
+  [Adapter.GCP]: initGCPKeystore,
   [Adapter.VAULT]: initVaultKeystore,
 };
 
@@ -15,6 +19,19 @@ export function initPrivateKeystoreFromEnv(adapter: Adapter): CloudPrivateKeysto
     throw new CloudKeystoreError(`Invalid private keystore adapter (${adapter})`);
   }
   return init();
+}
+
+export function initGCPKeystore(): GCPPrivateKeyStore {
+  const datastore = new Datastore({
+    namespace: getEnvVar('KS_DATASTORE_NS').required().asString(),
+  });
+  const kmsConfig = {
+    location: getEnvVar('KS_GCP_LOCATION').required().asString(),
+    keyRing: getEnvVar('KS_PRIV_KMS_KEYRING').required().asString(),
+    identityKeyId: getEnvVar('KS_PRIV_KMS_ID_KEY').required().asString(),
+    sessionEncryptionKeyId: getEnvVar('KS_PRIV_KMS_SESSION_ENC_KEY').required().asString(),
+  };
+  return new GCPPrivateKeyStore(new KeyManagementServiceClient(), datastore, kmsConfig);
 }
 
 export function initVaultKeystore(): VaultPrivateKeyStore {

--- a/src/lib/init.ts
+++ b/src/lib/init.ts
@@ -1,15 +1,15 @@
-import { PrivateKeyStore } from '@relaycorp/relaynet-core';
 import { get as getEnvVar } from 'env-var';
 
 import { Adapter } from './Adapter';
 import { VaultPrivateKeyStore } from './vault/VaultPrivateKeyStore';
 import { CloudKeystoreError } from './CloudKeystoreError';
+import { CloudPrivateKeystore } from './CloudPrivateKeystore';
 
 const ADAPTER_INITIALISERS = {
   [Adapter.VAULT]: initVaultKeystore,
 };
 
-export function initPrivateKeystoreFromEnv(adapter: Adapter): PrivateKeyStore {
+export function initPrivateKeystoreFromEnv(adapter: Adapter): CloudPrivateKeystore {
   const init = ADAPTER_INITIALISERS[adapter];
   if (!init) {
     throw new CloudKeystoreError(`Invalid private keystore adapter (${adapter})`);

--- a/src/lib/vault/VaultPrivateKeyStore.spec.ts
+++ b/src/lib/vault/VaultPrivateKeyStore.spec.ts
@@ -12,7 +12,7 @@ import * as https from 'https';
 
 import { catchPromiseRejection } from '../../testUtils/promises';
 import { base64Encode } from '../utils/base64';
-import { VaultPrivateKeyStore } from './vaultPrivateKeyStore';
+import { VaultPrivateKeyStore } from './VaultPrivateKeyStore';
 
 describe('VaultPrivateKeyStore', () => {
   const mockAxiosCreate = jest.spyOn(axios, 'create');

--- a/src/lib/vault/VaultPrivateKeyStore.spec.ts
+++ b/src/lib/vault/VaultPrivateKeyStore.spec.ts
@@ -428,4 +428,13 @@ describe('VaultPrivateKeyStore', () => {
       };
     }
   });
+
+  describe('close', () => {
+    test('Close method should do nothing', async () => {
+      mockAxiosCreate.mockReturnValue({ interceptors: { response: { use: jest.fn() } } } as any);
+      const store = new VaultPrivateKeyStore(stubVaultUrl, stubVaultToken, stubKvPath);
+
+      await store.close();
+    });
+  });
 });

--- a/src/lib/vault/VaultPrivateKeyStore.ts
+++ b/src/lib/vault/VaultPrivateKeyStore.ts
@@ -11,33 +11,13 @@ import { Agent as HttpAgent } from 'http';
 import { Agent as HttpsAgent } from 'https';
 
 import { base64Decode, base64Encode } from '../utils/base64';
+import {
+  KeyDataDecoded,
+  KeyDataEncoded,
+  SessionKeyDataDecoded,
+  SessionKeyDataEncoded,
+} from './keyData';
 import { VaultStoreError } from './VaultStoreError';
-
-interface BaseKeyDataEncoded {
-  readonly privateKey: string;
-}
-
-interface IdentityKeyDataEncoded extends BaseKeyDataEncoded {}
-
-interface SessionKeyDataEncoded extends BaseKeyDataEncoded {
-  readonly privateAddress: string;
-  readonly peerPrivateAddress?: string;
-}
-
-type KeyDataEncoded = IdentityKeyDataEncoded | SessionKeyDataEncoded;
-
-interface BaseKeyDataDecoded {
-  readonly privateKey: Buffer;
-}
-
-interface IdentityKeyDataDecoded extends BaseKeyDataDecoded {}
-
-interface SessionKeyDataDecoded extends BaseKeyDataDecoded {
-  readonly peerPrivateAddress: string;
-  readonly privateAddress: string;
-}
-
-type KeyDataDecoded = IdentityKeyDataDecoded | SessionKeyDataDecoded;
 
 export class VaultPrivateKeyStore extends PrivateKeyStore {
   protected readonly axiosClient: AxiosInstance;

--- a/src/lib/vault/VaultPrivateKeyStore.ts
+++ b/src/lib/vault/VaultPrivateKeyStore.ts
@@ -3,7 +3,6 @@
 import {
   derDeserializeRSAPrivateKey,
   derSerializePrivateKey,
-  PrivateKeyStore,
   SessionPrivateKeyData,
 } from '@relaycorp/relaynet-core';
 import axios, { AxiosInstance } from 'axios';
@@ -18,8 +17,9 @@ import {
   SessionKeyDataEncoded,
 } from './keyData';
 import { VaultStoreError } from './VaultStoreError';
+import { CloudPrivateKeystore } from '../CloudPrivateKeystore';
 
-export class VaultPrivateKeyStore extends PrivateKeyStore {
+export class VaultPrivateKeyStore extends CloudPrivateKeystore {
   protected readonly axiosClient: AxiosInstance;
 
   constructor(vaultUrl: string, vaultToken: string, kvPath: string) {
@@ -48,6 +48,10 @@ export class VaultPrivateKeyStore extends PrivateKeyStore {
       return null;
     }
     return derDeserializeRSAPrivateKey(keyData.privateKey);
+  }
+
+  public async close(): Promise<void> {
+    // There are no resources to release
   }
 
   protected async saveIdentityKey(privateAddress: string, privateKey: CryptoKey): Promise<void> {

--- a/src/lib/vault/VaultStoreError.ts
+++ b/src/lib/vault/VaultStoreError.ts
@@ -1,4 +1,6 @@
-export class VaultStoreError extends Error {
+import { CloudKeystoreError } from '../CloudKeystoreError';
+
+export class VaultStoreError extends CloudKeystoreError {
   constructor(message: string, responseErrorMessages?: readonly string[]) {
     const finalErrorMessage = responseErrorMessages
       ? `${message} (${responseErrorMessages.join(', ')})`

--- a/src/lib/vault/keyData.ts
+++ b/src/lib/vault/keyData.ts
@@ -1,0 +1,25 @@
+interface BaseKeyDataEncoded {
+  readonly privateKey: string;
+}
+
+interface IdentityKeyDataEncoded extends BaseKeyDataEncoded {}
+
+export interface SessionKeyDataEncoded extends BaseKeyDataEncoded {
+  readonly privateAddress: string;
+  readonly peerPrivateAddress?: string;
+}
+
+export type KeyDataEncoded = IdentityKeyDataEncoded | SessionKeyDataEncoded;
+
+interface BaseKeyDataDecoded {
+  readonly privateKey: Buffer;
+}
+
+interface IdentityKeyDataDecoded extends BaseKeyDataDecoded {}
+
+export interface SessionKeyDataDecoded extends BaseKeyDataDecoded {
+  readonly peerPrivateAddress: string;
+  readonly privateAddress: string;
+}
+
+export type KeyDataDecoded = IdentityKeyDataDecoded | SessionKeyDataDecoded;

--- a/src/testUtils/envVars.ts
+++ b/src/testUtils/envVars.ts
@@ -1,0 +1,28 @@
+import envVar from 'env-var';
+
+interface EnvVarSet {
+  readonly [key: string]: string | undefined;
+}
+
+export function configureMockEnvVars(envVars: EnvVarSet = {}): (envVars: EnvVarSet) => void {
+  const mockEnvVarGet = jest.spyOn(envVar, 'get');
+
+  function setEnvVars(newEnvVars: EnvVarSet): void {
+    mockEnvVarGet.mockReset();
+    mockEnvVarGet.mockImplementation((...args: readonly any[]) => {
+      const originalEnvVar = jest.requireActual('env-var');
+      const env = originalEnvVar.from(newEnvVars);
+
+      return env.get(...args);
+    });
+  }
+
+  beforeAll(() => setEnvVars(envVars));
+  beforeEach(() => setEnvVars(envVars));
+
+  afterAll(() => {
+    mockEnvVarGet.mockRestore();
+  });
+
+  return (newEnvVars: EnvVarSet) => setEnvVars(newEnvVars);
+}


### PR DESCRIPTION
To initialise a private key store from env vars.

Fixes #25.

BREAKING CHANGE: Individual key store classes are no longer exported.

- [x] Ensure all env vars used by `initPrivateKeyStoreFromEnv` share the same prefix (`KEYSTORE_(PRIV_)`)
- [x] Implement function to register PKI.js `CryptoEngine`
- [x] Document `initPrivateKeyStoreFromEnv`
