### PR TITLE
fix(GCP): Increase signature timeout to 1 second

### DIFF
--- a/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
+++ b/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
@@ -143,7 +143,7 @@ describe('onSign', () => {
     );
   });
 
-  test('Request should time out after 500ms', async () => {
+  test('Request should time out after 1000ms', async () => {
     const kmsClient = makeKmsClient();
     const provider = new GcpKmsRsaPssProvider(kmsClient);
 
@@ -151,7 +151,7 @@ describe('onSign', () => {
 
     expect(kmsClient.asymmetricSign).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ timeout: 500 }),
+      expect.objectContaining({ timeout: 1_000 }),
     );
   });
 

--- a/src/lib/gcp/GcpKmsRsaPssProvider.ts
+++ b/src/lib/gcp/GcpKmsRsaPssProvider.ts
@@ -68,7 +68,7 @@ export class GcpKmsRsaPssProvider extends RsaPssProvider {
     const [response] = await wrapGCPCallError(
       this.kmsClient.asymmetricSign(
         { data: plaintext, dataCrc32c: { value: plaintextChecksum }, name: key.kmsKeyVersionPath },
-        { timeout: 500 },
+        { timeout: 1_000 },
       ),
       'KMS signature request failed',
     );


### PR DESCRIPTION
Because it can take more than 500ms when the key hasn't been used in a while.

https://console.cloud.google.com/errors/detail/CNmz4qjSqISzdQ?project=gw-frankfurt-4065
https://console.cloud.google.com/errors/detail/CMOUqb3kt-q6rAE?project=gw-frankfurt-4065
https://console.cloud.google.com/errors/detail/CI2i_f-l58PvlAE?project=gw-frankfurt-4065