### PR TITLE
fix(GCP): Set all KMS ops to time out after 1s and be retried up to 3x

### DIFF
--- a/src/lib/gcp/GCPPrivateKeyStore.ts
+++ b/src/lib/gcp/GCPPrivateKeyStore.ts
@@ -14,7 +14,7 @@ import { Connection } from 'mongoose';
 import { GCPKeystoreError } from './GCPKeystoreError';
 import { GcpKmsRsaPssPrivateKey } from './GcpKmsRsaPssPrivateKey';
 import { wrapGCPCallError } from './gcpUtils';
-import { retrieveKMSPublicKey } from './kmsUtils';
+import { KMS_REQUEST_OPTIONS, retrieveKMSPublicKey } from './kmsUtils';
 import { CloudPrivateKeystore } from '../CloudPrivateKeystore';
 import { GcpKmsRsaPssProvider } from './GcpKmsRsaPssProvider';
 import { GcpIdentityKey } from './models/GcpIdentityKey';
@@ -158,7 +158,7 @@ export class GCPPrivateKeyStore extends CloudPrivateKeystore {
   private async createSigningKMSKeyVersion(kmsKeyName: string): Promise<string> {
     // Version 1 of the KMS key was already linked, so create a new version.
     const [kmsVersionResponse] = await wrapGCPCallError(
-      this.kmsClient.createCryptoKeyVersion({ parent: kmsKeyName }, { timeout: 500 }),
+      this.kmsClient.createCryptoKeyVersion({ parent: kmsKeyName }, KMS_REQUEST_OPTIONS),
       'Failed to create key version',
     );
     return kmsVersionResponse.name!;
@@ -197,7 +197,7 @@ export class GCPPrivateKeyStore extends CloudPrivateKeystore {
           plaintext: keySerialized,
           plaintextCrc32c: { value: calculateCRC32C(keySerialized) },
         },
-        { timeout: 500 },
+        KMS_REQUEST_OPTIONS,
       ),
       'Failed to encrypt session key with KMS',
     );
@@ -230,7 +230,7 @@ export class GCPPrivateKeyStore extends CloudPrivateKeystore {
           ciphertextCrc32c: { value: ciphertextCRC32C },
           name: kmsKeyName,
         },
-        { timeout: 500 },
+        KMS_REQUEST_OPTIONS,
       ),
       'Failed to decrypt session key with KMS',
     );

--- a/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
+++ b/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
@@ -155,6 +155,18 @@ describe('onSign', () => {
     );
   });
 
+  test('Request should be retried up to 3 times', async () => {
+    const kmsClient = makeKmsClient();
+    const provider = new GcpKmsRsaPssProvider(kmsClient);
+
+    await provider.sign(ALGORITHM, privateKey, PLAINTEXT);
+
+    expect(kmsClient.asymmetricSign).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ maxRetries: 3 }),
+    );
+  });
+
   test('API call errors should be wrapped', async () => {
     const callError = new Error('Bruno. There. I said it.');
     const provider = new GcpKmsRsaPssProvider(makeKmsClient(callError));

--- a/src/lib/gcp/GcpKmsRsaPssProvider.ts
+++ b/src/lib/gcp/GcpKmsRsaPssProvider.ts
@@ -7,6 +7,7 @@ import { bufferToArrayBuffer } from '../utils/buffer';
 import { GCPKeystoreError } from './GCPKeystoreError';
 import { GcpKmsRsaPssPrivateKey } from './GcpKmsRsaPssPrivateKey';
 import { wrapGCPCallError } from './gcpUtils';
+import { KMS_REQUEST_OPTIONS } from './kmsUtils';
 
 // See: https://cloud.google.com/kms/docs/algorithms#rsa_signing_algorithms
 const SUPPORTED_SALT_LENGTHS: readonly number[] = [
@@ -68,7 +69,7 @@ export class GcpKmsRsaPssProvider extends RsaPssProvider {
     const [response] = await wrapGCPCallError(
       this.kmsClient.asymmetricSign(
         { data: plaintext, dataCrc32c: { value: plaintextChecksum }, name: key.kmsKeyVersionPath },
-        { timeout: 1_000 },
+        KMS_REQUEST_OPTIONS,
       ),
       'KMS signature request failed',
     );

--- a/src/lib/gcp/kmsUtils.ts
+++ b/src/lib/gcp/kmsUtils.ts
@@ -4,6 +4,8 @@ import { bufferToArrayBuffer } from '../utils/buffer';
 import { sleep } from '../utils/timing';
 import { wrapGCPCallError } from './gcpUtils';
 
+export const KMS_REQUEST_OPTIONS = { timeout: 1_000, maxRetries: 3 };
+
 export async function retrieveKMSPublicKey(
   kmsKeyVersionName: string,
   kmsClient: KeyManagementServiceClient,


### PR DESCRIPTION
To fix https://console.cloud.google.com/errors/detail/CMOUqb3kt-q6rAE;service=frankfurt-gateway?project=gw-frankfurt-4065