### PR TITLE
fix(GCP): Increase KMS call retries to 8

### DIFF
--- a/src/lib/gcp/GCPPrivateKeyStore.spec.ts
+++ b/src/lib/gcp/GCPPrivateKeyStore.spec.ts
@@ -154,7 +154,7 @@ describe('Identity keys', () => {
         );
       });
 
-      test('Version creation call should time out after 3 seconds', async () => {
+      test('Version creation call should time out after 2 seconds', async () => {
         const kmsClient = makeKmsClient();
         const store = new GCPPrivateKeyStore(kmsClient, getDBConnection(), KMS_CONFIG);
 
@@ -162,11 +162,11 @@ describe('Identity keys', () => {
 
         expect(kmsClient.createCryptoKeyVersion).toHaveBeenCalledWith(
           expect.anything(),
-          expect.objectContaining({ timeout: 3_000 }),
+          expect.objectContaining({ timeout: 2_000 }),
         );
       });
 
-      test('Version creation call should be retried up to 5 times', async () => {
+      test('Version creation call should be retried up to 8 times', async () => {
         const kmsClient = makeKmsClient();
         const store = new GCPPrivateKeyStore(kmsClient, getDBConnection(), KMS_CONFIG);
 
@@ -174,7 +174,7 @@ describe('Identity keys', () => {
 
         expect(kmsClient.createCryptoKeyVersion).toHaveBeenCalledWith(
           expect.anything(),
-          expect.objectContaining({ maxRetries: 5 }),
+          expect.objectContaining({ maxRetries: 8 }),
         );
       });
 
@@ -682,7 +682,7 @@ describe('Session keys', () => {
         );
       });
 
-      test('Request should time out after 3 seconds', async () => {
+      test('Request should time out after 2 seconds', async () => {
         const kmsClient = makeKMSClient();
         const store = new GCPPrivateKeyStore(kmsClient, getDBConnection(), KMS_CONFIG);
 
@@ -694,11 +694,11 @@ describe('Session keys', () => {
 
         expect(kmsClient.encrypt).toHaveBeenCalledWith(
           expect.anything(),
-          expect.objectContaining({ timeout: 3_000 }),
+          expect.objectContaining({ timeout: 2_000 }),
         );
       });
 
-      test('Request should be retried up to 5 times', async () => {
+      test('Request should be retried up to 8 times', async () => {
         const kmsClient = makeKMSClient();
         const store = new GCPPrivateKeyStore(kmsClient, getDBConnection(), KMS_CONFIG);
 
@@ -710,7 +710,7 @@ describe('Session keys', () => {
 
         expect(kmsClient.encrypt).toHaveBeenCalledWith(
           expect.anything(),
-          expect.objectContaining({ maxRetries: 5 }),
+          expect.objectContaining({ maxRetries: 8 }),
         );
       });
 
@@ -918,7 +918,7 @@ describe('Session keys', () => {
         );
       });
 
-      test('Request should time out after 3 seconds', async () => {
+      test('Request should time out after 2 seconds', async () => {
         const kmsClient = makeKMSClient();
         const store = new GCPPrivateKeyStore(kmsClient, getDBConnection(), KMS_CONFIG);
         await saveKey();
@@ -927,11 +927,11 @@ describe('Session keys', () => {
 
         expect(kmsClient.decrypt).toHaveBeenCalledWith(
           expect.anything(),
-          expect.objectContaining({ timeout: 3_000 }),
+          expect.objectContaining({ timeout: 2_000 }),
         );
       });
 
-      test('Request should be retried up to 5 times', async () => {
+      test('Request should be retried up to 8 times', async () => {
         const kmsClient = makeKMSClient();
         const store = new GCPPrivateKeyStore(kmsClient, getDBConnection(), KMS_CONFIG);
         await saveKey();
@@ -940,7 +940,7 @@ describe('Session keys', () => {
 
         expect(kmsClient.decrypt).toHaveBeenCalledWith(
           expect.anything(),
-          expect.objectContaining({ maxRetries: 5 }),
+          expect.objectContaining({ maxRetries: 8 }),
         );
       });
 

--- a/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
+++ b/src/lib/gcp/GcpKmsRsaPssProvider.spec.ts
@@ -143,7 +143,7 @@ describe('onSign', () => {
     );
   });
 
-  test('Request should time out after 3 seconds', async () => {
+  test('Request should time out after 2 seconds', async () => {
     const kmsClient = makeKmsClient();
     const provider = new GcpKmsRsaPssProvider(kmsClient);
 
@@ -151,11 +151,11 @@ describe('onSign', () => {
 
     expect(kmsClient.asymmetricSign).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ timeout: 3_000 }),
+      expect.objectContaining({ timeout: 2_000 }),
     );
   });
 
-  test('Request should be retried up to 5 times', async () => {
+  test('Request should be retried up to 8 times', async () => {
     const kmsClient = makeKmsClient();
     const provider = new GcpKmsRsaPssProvider(kmsClient);
 
@@ -163,7 +163,7 @@ describe('onSign', () => {
 
     expect(kmsClient.asymmetricSign).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ maxRetries: 5 }),
+      expect.objectContaining({ maxRetries: 8 }),
     );
   });
 

--- a/src/lib/gcp/kmsUtils.ts
+++ b/src/lib/gcp/kmsUtils.ts
@@ -4,7 +4,13 @@ import { bufferToArrayBuffer } from '../utils/buffer';
 import { sleep } from '../utils/timing';
 import { wrapGCPCallError } from './gcpUtils';
 
-export const KMS_REQUEST_OPTIONS = { timeout: 3_000, maxRetries: 5 };
+/**
+ * The official KMS library will often try to make API requests before the authentication with the
+ * Application Default Credentials is complete, which will result in errors like "Exceeded
+ * maximum number of retries before any response was received". We're working around that by
+ * retrying a few times.
+ */
+export const KMS_REQUEST_OPTIONS = { timeout: 2_000, maxRetries: 8 };
 
 export async function retrieveKMSPublicKey(
   kmsKeyVersionName: string,


### PR DESCRIPTION
And decrease timeout to 2 seconds.

A continuation of #133 because we hit the same issue again, although it's now very rare.